### PR TITLE
Update game: New Minecraft Bedrock Edition server is up

### DIFF
--- a/src/islan.nl/index.html
+++ b/src/islan.nl/index.html
@@ -204,11 +204,11 @@
 									Android, iOS en via een <a
 										href="https://github.com/Pugmatt/BedrockConnect">workaround</a> ook op PS4 en
 									Switch.</p>
-								<p class="card-text">Game mode is vanilla: normal survival.</p>
+								<p class="card-text">Game mode is vanilla: normal survival, zonder PvP.</p>
 								<table class="table table-borderless align-top">
 									<tr>
 										<th scope="row">Address:</th>
-										<td>minecraft.islan.nl (WIP)</td>
+										<td>minecraft.islan.nl</td>
 									</tr>
 									<tr>
 										<th scope="row">Port:</th>


### PR DESCRIPTION
New world, not same as on the ISBUMP world
IPv4 only, IPv6 is not enabled.

```
Server name: ISLAN Survival
Game mode: Suvival
Difficulty: normal
Allow cheats: false
Max players: 20
Online mode: true
Player idle timeout: 5 (min)
```